### PR TITLE
Marking tailwind styles as important

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,4 +13,5 @@ module.exports = {
     extend: {},
   },
   plugins: [],
+  important: true,
 }


### PR DESCRIPTION
- Marked tailwind css commands as important, this is necessary because the intended use of tailwind is a more fine tuned styling to be used on top of Material UI components