### PR TITLE
Fixed Quotation Marks and Symbols - Successful `npm run build`

### DIFF
--- a/src/components/elements/storyTranslationAndCitation.tsx
+++ b/src/components/elements/storyTranslationAndCitation.tsx
@@ -23,7 +23,7 @@ export const StoryTranslationAndCitation = (props: any) => {
     const ConstructTranslationCitation = (english_translation_author: string, macomber_id: string, macomber_title: string) => {
         const last_modified_date = new Date();
         if (english_translation_author != null && macomber_id != null && macomber_title != null) {
-            return <> <Typography variant="subtitle1"> <b>TO CITE THIS TRANSLATION</b> </Typography> <Typography variant="body2"> {english_translation_author}. "ID {macomber_id}: {macomber_title}" Täˀammərä Maryam (Miracle of Mary) Stories, edited by Wendy Laura Belcher, Jeremy Brown, Mehari Worku, and Dawit Muluneh. Princeton: Princeton Ethiopian, Eritrean, and Egyptian Miracles of Mary project. http://pemm.princeton.edu/story-detail/{macomber_id}. Last modified: {last_modified_date.toLocaleDateString().replace(/\//ig, '.')}.</Typography> </>
+            return <> <Typography variant="subtitle1"> <b>TO CITE THIS TRANSLATION</b> </Typography> <Typography variant="body2"> {english_translation_author}. &quot;ID {macomber_id}: {macomber_title}.&quot; In <i>Täˀammərä Maryam (Miracle of Mary) Stories</i>, edited by Wendy Laura Belcher, Jeremy Brown, Mehari Worku, and Dawit Muluneh. Princeton: Princeton Ethiopian, Eritrean, and Egyptian Miracles of Mary project. http://pemm.princeton.edu/story-detail/{macomber_id}. Last modified: {last_modified_date.toLocaleDateString().replace(/\//ig, '.')}.</Typography> </>
         }
         return;
     }
@@ -39,16 +39,16 @@ export const StoryTranslationAndCitation = (props: any) => {
     // Function to write amharic citation, if any
     const ConstructAmharicCitation = (appears_in_amharic: boolean, tgs: string, tgs_folio_start: number) => {
         if (appears_in_amharic == true && tgs == "TGS (EOTC) 1968") {
-            return <> <Typography variant="body2"> <b>Amharic:</b> Täsfa Giyorgis, ed. Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña [the Miracles of Mary in Gəˁəz and Amharic: 111 Miracles]. 2nd ed. Addis Ababa, Ethiopia, 1968, page {tgs_folio_start}</Typography> </>
+            return <> <Typography variant="body2"> <b>Amharic:</b> Täsfa Giyorgis, ed. <i>Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña</i> [the Miracles of Mary in Gəˁəz and Amharic: 111 Miracles]. 2nd ed. Addis Ababa, Ethiopia, 1968, page {tgs_folio_start}.</Typography> </>
         } 
         else if (appears_in_amharic == true && tgs == "TGS (EOTC) 1971") {
-            return <> <Typography variant="body2"> <b>Amharic:</b> Täsfa Gäbrä Śəllase, ed. Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña [the Miracles of Mary in Gəˁəz and Amharic: Part One: 270 Miracles]. Addis Ababa, Ethiopia: Täsfa Gäbrä Śəllase Printing Press, 1971, page {tgs_folio_start}</Typography> </>
+            return <> <Typography variant="body2"> <b>Amharic:</b> Täsfa Gäbrä Śəllase, ed. <i>Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña</i> [the Miracles of Mary in Gəˁəz and Amharic: Part One: 270 Miracles]. Addis Ababa, Ethiopia: Täsfa Gäbrä Śəllase Printing Press, 1971, page {tgs_folio_start}.</Typography> </>
         }
         else if (appears_in_amharic == true && tgs == "TGS (EOTC) 1996") {
-            return <> <Typography variant="body2"> <b>Amharic:</b> Täsfa Gäbrä Śəllase, ed. Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña [the Miracles of Mary in Gəˁəz and Amharic: Part Two: 402 Miracles]. Addis Ababa, Ethiopia: Täsfa Gäbrä Śəllase Printing Press, 1996, page {tgs_folio_start}</Typography> </>
+            return <> <Typography variant="body2"> <b>Amharic:</b> Täsfa Gäbrä Śəllase, ed. <i>Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña</i> [the Miracles of Mary in Gəˁəz and Amharic: Part Two: 402 Miracles]. Addis Ababa, Ethiopia: Täsfa Gäbrä Śəllase Printing Press, 1996, page {tgs_folio_start}.</Typography> </>
         }
         else if (appears_in_amharic == true && tgs == "TGS (EOTC) 2014") {
-            return <> <Typography variant="body2"> <b>Amharic:</b> Gäbrä Śəllase Bərhan, ed. Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña [the Miracles of Mary in Gəˁəz and Amharic: 366 Miracles]. Aksum, Ethiopia: Gäbrä Śəllase Bərhan Printing Press, 2014, page {tgs_folio_start}</Typography> </>
+            return <> <Typography variant="body2"> <b>Amharic:</b> Gäbrä Śəllase Bərhan, ed. <i>Täˀammərä Maryam Bä-Gəˁəz Ənna Bä-Amarəñña</i> [the Miracles of Mary in Gəˁəz and Amharic: 366 Miracles]. Aksum, Ethiopia: Gäbrä Śəllase Bərhan Printing Press, 2014, page {tgs_folio_start}.</Typography> </>
         }
         return;
     }
@@ -56,7 +56,7 @@ export const StoryTranslationAndCitation = (props: any) => {
     // Function to write french citation, if any
     const ConstructFrenchCitation = (appears_in_french: boolean, colin_item: string) => {
         if (appears_in_french == true) {
-            return <> <Typography variant="body2"> <b>French:</b> Colin, Gérard. <i>Le Livre Éthiopien Des Miracles De Marie (Taamra Mâryâm).</i> Paris: Les Editions du Cerf, 2004, item {colin_item}</Typography> </>
+            return <> <Typography variant="body2"> <b>French:</b> Colin, Gérard. <i>Le Livre Éthiopien Des Miracles De Marie (Taamra Mâryâm).</i> Paris: Les Editions du Cerf, 2004, item {colin_item}.</Typography> </>
         }
         return;
     }
@@ -64,8 +64,9 @@ export const StoryTranslationAndCitation = (props: any) => {
     // Function to write ge'ez print edition, if any
     const ConstructGeEzPrintEdition = (print_version: string) => {
         if (print_version != null) {
-            return <> <Typography variant="body2"> <b>Ge'ez Print Edition(s):</b> {print_version}</Typography> </>
+            return <> <Typography variant="body2"> <b>Gə&#705;əz Print Edition(s):</b> {print_version}</Typography> </>
         }
+        return;
     }
 
     // Function to write latin citation, if any
@@ -81,6 +82,7 @@ export const StoryTranslationAndCitation = (props: any) => {
         if (appears_in_italian == true) {
             return <> <Typography variant="body2"> <b>Italian:</b> Cerulli, Enrico. <i>Il Libro Etiopico Dei Miracoli Di Maria E Le Sue Fonti Nelle Letterature Del Medio Evo Latino. Universita Di Roma, Studi Orientali Pubblicati a Cura Della Scuola Orientale.</i> Rome: Giovanni Bardi Editore, 1943.</Typography> </>
         }
+        return;
     }
 
     return (


### PR DESCRIPTION
Fixed quotations and symbols for `npm run build`