### PR TITLE
Bug Fixes - Story Detail Page

### DIFF
--- a/src/components/elements/storyInformationWidget.tsx
+++ b/src/components/elements/storyInformationWidget.tsx
@@ -1,7 +1,8 @@
 import Typography from '@mui/material/Typography';
+import { Instances } from '../types/instances';
 
 export const StoryInformationWidget = (props: any) => {
-    const instance = props.instance;
+    const INSTANCES: Instances[] = props.instances;
     const story = props.story;
 
     // Function to write story type, if any
@@ -44,12 +45,53 @@ export const StoryInformationWidget = (props: any) => {
         return;
     }
 
-    // Function to write earliest attested instance of the story, if any
-    const ConstructEarliestAttestedInstance = (manuscript_date_range_start: number, manuscript_date_range_end: number) => {
-        if (manuscript_date_range_start != null && manuscript_date_range_end != null) {
-            return <> <Typography variant="body2"> <b>Earliest Attested Instance of Story:</b> {manuscript_date_range_start}-{manuscript_date_range_end}  </Typography> </>
+    // Function to find maximum date range end, if any
+    function FindMaximumDateRangeEnd(instances: Instances[]) {
+        var maxValue = Number.MIN_VALUE;
+        if (instances) {
+            for (var i = 0; i < instances.length; i++) {
+                let date_range_end = instances[i].manuscript_date_range_end;
+                if (date_range_end) {
+                    if (date_range_end > maxValue) {
+                        maxValue = date_range_end;
+                    }
+                }
+            }
         }
-        return;
+        return maxValue;
+    }
+
+    // Function to find minimum date range start, if any
+    function FindMinimumDateRangeStart(instances: Instances[]) {
+        var minValue = Number.MAX_VALUE;
+        if (instances) {
+            for (var i = 0; i < instances.length; i++) {
+                let date_range_start = instances[i].manuscript_date_range_start;
+                if (date_range_start) {
+                    if (date_range_start < minValue) {
+                        minValue = date_range_start;
+                    }
+                }
+            }
+        }
+        return minValue;
+    }
+
+    // Function to write the minimum (earliest year) manuscript date range start
+    const MinDateRangeStart = (instances: Instances[]) => {
+        var minValue = FindMinimumDateRangeStart(instances);
+        return <> {minValue} </>;
+    }
+
+    // Function to write the maximum (latest year) manuscript date range end
+    const MaxDateRangeEnd = (instances: Instances[]) => {
+        var maxValue = FindMaximumDateRangeEnd(instances);
+        return <> {maxValue} </>;
+    }
+
+    // Function to write the earliest attested instance of the story with the manuscript date range start and end
+    const ConstructEarliestAttestedInstanceOfTheStory = (instances: Instances[]) => {
+        return <> <Typography variant="body2"> <b>Earliest Attested Instance of the Story:</b> {MinDateRangeStart(instances)}-{MaxDateRangeEnd(instances)} </Typography> </>
     }
 
     // Function to write earliest manuscripts in which story appears, if any
@@ -84,6 +126,13 @@ export const StoryInformationWidget = (props: any) => {
             return <> <Typography variant="body2"> <b>Incipit(s):</b> {canonical_incipit} ... </Typography> </>
         }
         return;
+    }
+
+    // Function to write PEMM ID, if any
+    const ConstructPEMMID = (pemm_id: number) => {
+        if (pemm_id != null) {
+            return <> PEMM ID {pemm_id}; </>
+        }
     }
 
     // Function to write Macomber ID, if any
@@ -127,9 +176,9 @@ export const StoryInformationWidget = (props: any) => {
     }
 
     // Function to write id numbers (hamburg id, clavis id, csm number, poncelet number, macomber id), if any
-    const ConstructIDNumbers = (hamburg_id: string, clavis_id: string, csm_number: number, poncelet_number: number, macomber_id: string) => {
-        if (hamburg_id != null || clavis_id != null || macomber_id != null || csm_number != null || poncelet_number != null) {
-            return <> <Typography variant="body2"> <b>ID Numbers:</b> {ConstructMacomberID(macomber_id)} {ConstructHamburgID(hamburg_id)} {ConstructClavisId(clavis_id)} {ConstructCantigasID(csm_number)} {ConstructPonceletID(poncelet_number)}</Typography> </>
+    const ConstructIDNumbers = (pemm_id: number, hamburg_id: string, clavis_id: string, csm_number: number, poncelet_number: number, macomber_id: string) => {
+        if (pemm_id != null || hamburg_id != null || clavis_id != null || macomber_id != null || csm_number != null || poncelet_number != null) {
+            return <> <Typography variant="body2"> <b>ID Numbers:</b> {ConstructPEMMID(pemm_id)} {ConstructMacomberID(macomber_id)} {ConstructHamburgID(hamburg_id)} {ConstructClavisId(clavis_id)} {ConstructCantigasID(csm_number)} {ConstructPonceletID(poncelet_number)}</Typography> </>
         }
         return;
     }
@@ -159,12 +208,12 @@ export const StoryInformationWidget = (props: any) => {
             <h2>{ConstructKeywords(story.macomber_keywords)}</h2>
             <br></br>
             <Typography variant="subtitle1"> <b>TECHNICAL INFORMATION</b> </Typography>
-            <h2>{ConstructEarliestAttestedInstance(instance.manuscript_date_range_start, instance.manuscript_date_range_end)}</h2>
+            <h2>{ConstructEarliestAttestedInstanceOfTheStory(INSTANCES)}</h2>
             <h2>{ConstructEarliestManuscriptsInWhichStoryAppears(story.names_of_mss_with_earliest_attestation)}</h2>
             <h2>{ConstructTotalRecords(story.total_records)}</h2>
             <h2>{ConstructNumberOfIncipits(story.total_incipits_in_the_itool)}</h2>
             <h2>{ConstructIncipit(story.canonical_incipit, story.english_translation_manuscript_name, story.english_translation_manuscript_folio)}</h2>
-            <h2>{ConstructIDNumbers(story.hamburg_id, story.clavis_id, story.csm_number, story.poncelet_number, story.macomber_id)}</h2>
+            <h2>{ConstructIDNumbers(story.pemm_id, story.hamburg_id, story.clavis_id, story.csm_number, story.poncelet_number, story.macomber_id)}</h2>
         </>
     );
 };

--- a/src/data/story13.ts
+++ b/src/data/story13.ts
@@ -1,4 +1,4 @@
-import type {Paintings} from '../components/types/paintings';
+import type { Paintings } from '../components/types/paintings';
 import type { Stories } from '../components/types/stories';
 import type { Instances } from '../components/types/instances';
 
@@ -49,11 +49,6 @@ export const STORY_13_TEST_DATA: Stories = {
   "folio_end": "124r",
 };
 
-export const STORY_13_TEST_INSTANCE: Instances = {
-  "manuscript_date_range_start": 1700,
-  "manuscript_date_range_end": 1799,
-};
-
 export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
   {
     "manuscript": "Z-Paris (BNF) 63",
@@ -63,6 +58,8 @@ export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
     "folio_start": null,
     "scan_start": null,
     "date_range_mean": 1750,
+    "manuscript_date_range_start": 1737,
+    "manuscript_date_range_end": 1765,
   },
   {
     "manuscript": "Z-Paris (BNF) 62",
@@ -72,6 +69,8 @@ export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
     "folio_start": null,
     "scan_start": null,
     "date_range_mean": 1550,
+    "manuscript_date_range_start": 1737,
+    "manuscript_date_range_end": 1765,
   },
   {
     "manuscript": "Z-Paris (BNF) 60",
@@ -81,6 +80,8 @@ export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
     "folio_start": null,
     "scan_start": null,
     "date_range_mean": 1650,
+    "manuscript_date_range_start": 1737,
+    "manuscript_date_range_end": 1746,
   },
   {
     "manuscript": "YOr-Jerusalem (NLI) 14",
@@ -90,6 +91,8 @@ export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
     "folio_start": "22r",
     "scan_start": null,
     "date_range_mean": 1900,
+    "manuscript_date_range_start": 1750,
+    "manuscript_date_range_end": 1765,
   },
   {
     "manuscript": "VOHD (HMML) 63",
@@ -99,6 +102,8 @@ export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
     "folio_start": "5r",
     "scan_start": "9b",
     "date_range_mean": 1650,
+    "manuscript_date_range_start": 1737,
+    "manuscript_date_range_end": 1740,
   },
   {
     "manuscript": "VOHD (HMML) 118",
@@ -108,6 +113,8 @@ export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
     "folio_start": "13r",
     "scan_start": "17b",
     "date_range_mean": 1600,
+    "manuscript_date_range_start": 1737,
+    "manuscript_date_range_end": 1755,
   },
   {
     "manuscript": "VOHD (HMML) 105",
@@ -117,19 +124,24 @@ export const STORY_13_INSTANCE_TEST_DATA: Instances[] = [
     "folio_start": "18v",
     "scan_start": "19a",
     "date_range_mean": 1750,
+    "manuscript_date_range_start": 1900,
+    "manuscript_date_range_end": 1735,
   }
 ]
 
-export const STORY_13_IMAGE_TEST_DATA: Paintings[] = 
+export const STORY_13_IMAGE_TEST_DATA: Paintings[] =
   [
     {
-      "image_link": "https://api.bl.uk/image/iiif/ark:/81055/vdc_100054933823.0x000027/full/full/0/default.jpg"},
+      "image_link": "https://api.bl.uk/image/iiif/ark:/81055/vdc_100054933823.0x000027/full/full/0/default.jpg"
+    },
     {
       "image_link":
-        "https://api.bl.uk/image/iiif/ark:/81055/vdc_100054923333.0x00004e/full/full/0/default.jpg"},
+        "https://api.bl.uk/image/iiif/ark:/81055/vdc_100054923333.0x00004e/full/full/0/default.jpg"
+    },
     {
       "image_link":
-        "https://api.bl.uk/image/iiif/ark:/81055/vdc_100054923333.0x00004f/full/full/0/default.jpg"},
+        "https://api.bl.uk/image/iiif/ark:/81055/vdc_100054923333.0x00004f/full/full/0/default.jpg"
+    },
     {
       "image_link":
         "https://api.bl.uk/image/iiif/ark:/81055/vdc_100054933823.0x000028/full/full/0/default.jpg"

--- a/src/pages/stories/[canonicalId].tsx
+++ b/src/pages/stories/[canonicalId].tsx
@@ -10,7 +10,7 @@ import { CycleHyperlink } from '../../components/elements/cycleHyperlink';
 import { StoryInformationWidget } from '../../components/elements/storyInformationWidget';
 import { StoryTranslationAndCitation } from '../../components/elements/storyTranslationAndCitation';
 import { ManuscriptInformationBox } from '../../components/elements/manuscriptInformationBox';
-import { STORY_13_TEST_DATA, STORY_13_TEST_INSTANCE, STORY_13_IMAGE_TEST_DATA, STORY_13_INSTANCE_TEST_DATA } from '../../data/story13';
+import { STORY_13_TEST_DATA, STORY_13_IMAGE_TEST_DATA, STORY_13_INSTANCE_TEST_DATA } from '../../data/story13';
 import { TEST_DATA } from '../../data/stories';
 import { STATIC_PAGES } from '../../data/story_ids';
 import Typography from '@mui/material/Typography';
@@ -64,17 +64,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
           story = story_res.data[0];
         }
       }
-      
-      var instance: Instances = {};
-      if (process.env['ENVIRONMENT'] == "DEV") {
-        instance = STORY_13_TEST_INSTANCE;
-      }
-      else {
-        const instance_res = await axios(process.env.REACT_APP_API + 'instances/' + canonicalId);
-        if (instance_res.data.length > 0) {
-          instance = instance_res.data[0];
-        }
-      }
 
       var all_stories: Stories[] = [];
       if (process.env['ENVIRONMENT'] == "DEV") {
@@ -100,7 +89,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
             imageUris: imageUris,
             story: story,
             all_stories: all_stories,
-            instance: instance,
             instances: instances
           }
         }
@@ -111,7 +99,6 @@ export const getStaticProps: GetStaticProps = async (context) => {
             data: {
               imageUris: [],
               story: {},
-              instance: {},
               all_stories: [],
               instances: []
             }
@@ -169,7 +156,7 @@ const StoriesDetailPage: NextPage = ({ data }: InferGetStaticPropsType<typeof ge
 
             <div className="">
               <StoryInformationWidget story={data.story}
-                                      instance = {data.instance}/>
+                                      instances = {data.instances}/>
             </div>
           </div>
 
@@ -224,7 +211,7 @@ const StoriesDetailPage: NextPage = ({ data }: InferGetStaticPropsType<typeof ge
           <TabPanel value={value} index={1}>
             <div className="overflow-hidden m-1">
               <StoryInformationWidget story={data.story}
-                                      instance = {data.instance}/>
+                                      instances = {data.instances}/>
             </div>
           </TabPanel>
           <TabPanel value={value} index={2}>


### PR DESCRIPTION
- Added `pemm_id` to the '**ID Numbers**' field.
- Added a function to construct the '**Earliest Attested Instance of the Story**' field, e.g. '1737 - 1765' in Story 13.
- Added functions to find the `manuscript_date_range_start` (Minimum) and `manuscript_date_range_end` (Maximum).
- Removed duplication of Instances[], as there is already an API that gets all the story instances for a particular story.
- TODO: Research how to construct a table using Material-UI for the Manuscripts page.

<img width="776" alt="bug-fixes-story-detail" src="https://user-images.githubusercontent.com/67703799/200414005-60d2bb03-6d83-4e68-b154-7bf268d0272f.png">
