### PR TITLE
Issac - Sprint 1 Tasks

### DIFF
--- a/src/components/common/navbar.tsx
+++ b/src/components/common/navbar.tsx
@@ -215,41 +215,98 @@ const NavBar = () => {
                                 open={Boolean(anchorElNav)}
                                 onClose={handleCloseNavMenu}
                             >
-                                <MenuItem onClick={handleCloseNavMenu}>
+                                <div>
                                     <Link href="/stories">
-                                        <Typography textAlign="center" color="primary">
-                                            Stories
-                                        </Typography>
+                                        <Button style={{ textTransform: 'none', width: '100%' }} color="primary">Stories</Button>
                                     </Link>
-                                </MenuItem>
-                                <MenuItem onClick={handleCloseNavMenu}>
-                                    <Link href="/paintings">
-                                        <Typography textAlign="center" color="primary">
-                                            Paintings
-                                        </Typography>
-                                    </Link>
-                                </MenuItem>
-                                <MenuItem onClick={handleCloseNavMenu}>
+                                </div>
+
+                                <div>
+                                    <Button style={{ textTransform: 'none', width: '100%' }} color="primary" onClick={handleClickPaintings}>
+                                        Paintings
+                                    </Button>
+                                    <Menu
+                                        anchorEl={anchorElPaintings}
+                                        open={Boolean(anchorElPaintings)}
+                                        onClose={handleClose}
+                                    >
+                                        <Link href="/paintings">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>All Paintings</MenuItem>
+                                        </Link>
+                                        <Link href="/paintings/story">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Paintings by Story</MenuItem>
+                                        </Link>
+                                        <Link href="/paintings/manuscript">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Paintings by Manuscripts</MenuItem>
+                                        </Link>
+                                    </Menu>
+                                </div>
+
+                                <div>
                                     <Link href="/manuscripts">
-                                        <Typography textAlign="center" color="primary">
-                                            Manuscripts
-                                        </Typography>
+                                        <Button style={{ textTransform: 'none', width: '100%' }} color="primary">Manuscripts</Button>
                                     </Link>
-                                </MenuItem>
-                                <MenuItem onClick={handleCloseNavMenu}>
-                                    <Link href="/research/incipit-tool">
-                                        <Typography textAlign="center" color="primary">
-                                            Research Tools
-                                        </Typography>
-                                    </Link>
-                                </MenuItem>
-                                <MenuItem onClick={handleCloseNavMenu}>
-                                    <Link href="/about/mission">
-                                        <Typography textAlign="center" color="primary">
-                                            About
-                                        </Typography>
-                                    </Link>
-                                </MenuItem>
+                                </div>
+
+                                <div>
+                                    <Button style={{ textTransform: 'none', width: '100%' }} color="primary" onClick={handleClickResearch}>
+                                        Research Tools
+                                    </Button>
+                                    <Menu
+                                        anchorEl={anchorElResearch}
+                                        open={Boolean(anchorElResearch)}
+                                        onClose={handleClose}
+                                    >
+                                        <Link href="/research/incipit-tool">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Incipit Tool</MenuItem>
+                                        </Link>
+                                        <Link href="/research/arabic-manuscripts">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Arabic Manuscripts</MenuItem>
+                                        </Link>
+                                        <Link href="/research/arabic-stories">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Arabic Stories</MenuItem>
+                                        </Link>
+                                        <Link href="/research/maps">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Maps</MenuItem>
+                                        </Link>
+                                        <Link href="/research/spellings">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Interchangeable Spellings of Ethiopic Terms</MenuItem>
+                                        </Link>
+                                        <Link href="/research/research-posts">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Research Posts</MenuItem>
+                                        </Link>
+                                        <Link href="/research/macomber">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Macomber Handlist</MenuItem>
+                                        </Link>
+                                        <Link href="/research/repositories">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>List of Repositories</MenuItem>
+                                        </Link>
+                                        <Link href="/research/bibliography">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Bibliography</MenuItem>
+                                        </Link>
+                                    </Menu>
+                                </div>
+
+                                <div>
+                                    <Button style={{ textTransform: 'none', width: '100%' }} color="primary" onClick={handleClickAbout}>
+                                        About
+                                    </Button>
+                                    <Menu
+                                        anchorEl={anchorElAbout}
+                                        open={Boolean(anchorElAbout)}
+                                        onClose={handleClose}
+                                    >
+                                        <Link href="/about/people">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>People</MenuItem>
+                                        </Link>
+                                        <Link href="/about/mission">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Mission</MenuItem>
+                                        </Link>
+                                        <Link href="/about/connect">
+                                            <MenuItem onClick={handleClose} sx={menuStyles}>Connect</MenuItem>
+                                        </Link>
+                                    </Menu>
+                                </div>
                             </Menu>
                         </Box>
                     </Box>

--- a/src/components/elements/manuscriptInformationBox.tsx
+++ b/src/components/elements/manuscriptInformationBox.tsx
@@ -1,6 +1,6 @@
 import Typography from '@mui/material/Typography';
 
-// List of all the centiries we currenlty have story instances in.
+// List of all the centuries we currently have story instances in.
 const CENTURIES: [number, string][] = [[13, '1300s'], [14, '1400s'], [15, '1500s'], [16, '1600s'], [17, '1700s'], [18, '1800s'], [19, '1900s']];
 
 export const ManuscriptInformationBox = (props: any) => {
@@ -8,10 +8,10 @@ export const ManuscriptInformationBox = (props: any) => {
 
     // Takes in a single story century and a list of story instances and returns
     // semicolon separated element of all the manuscripts in that century
-    const FindManuscriptsOfCentury = (story_century: number, instances:any) => {
+    const FindManuscriptsOfCentury = (story_century: number, instances: any) => {
         let manuscripts = [];
         for (const instance of instances) {
-            let century_number = Math.ceil(instance.date_range_mean/100);
+            let century_number = Math.floor(instance.date_range_mean / 100);
             if (century_number == story_century) {
                 if (instance.scan_start) {
                     manuscripts.push(instance.manuscript + " s. " + instance.scan_start);
@@ -20,7 +20,7 @@ export const ManuscriptInformationBox = (props: any) => {
                 }
             }
         }
-        return manuscripts.map(function(manuscript, i){
+        return manuscripts.map(function (manuscript, i) {
             return (
                 <div key={i} className="inline-block">
                     {manuscript + "; "}
@@ -30,9 +30,9 @@ export const ManuscriptInformationBox = (props: any) => {
     }
 
     // Returns True if any of the story instances were written in the story century.
-    const HasManuscirptsInCentury = (story_century: number, instances:any) => {
+    const HasManuscriptsInCentury = (story_century: number, instances: any) => {
         for (const instance of instances) {
-            let century_number = Math.ceil(instance.date_range_mean/100);
+            let century_number = Math.floor(instance.date_range_mean / 100);
             if (century_number == story_century) {
                 return true
             }
@@ -44,10 +44,10 @@ export const ManuscriptInformationBox = (props: any) => {
         <>
             <Typography variant="subtitle1"> <b>MANUSCRIPTS</b> </Typography>
             <Typography variant="body2"> GMP Manuscripts in which story appears (with page or folio start): </Typography>
-            {CENTURIES.map(function(century, i){
+            {CENTURIES.map(function (century, i) {
                 return (
-                    <div className='block' key={i}> 
-                        <div className='font-bold inline'>{ HasManuscirptsInCentury(century[0], INSTANCES) && century[1] + ": " }</div>  {FindManuscriptsOfCentury(century[0], INSTANCES)} 
+                    <div className='block' key={i}>
+                        <div className='font-bold inline'>{HasManuscriptsInCentury(century[0], INSTANCES) && century[1] + ": "}</div>  {FindManuscriptsOfCentury(century[0], INSTANCES)}
                     </div>
                 )
             })}

--- a/src/components/elements/storyInformationWidget.tsx
+++ b/src/components/elements/storyInformationWidget.tsx
@@ -45,15 +45,19 @@ export const StoryInformationWidget = (props: any) => {
         return;
     }
 
-    // Function to find maximum date range end, if any
-    function FindMaximumDateRangeEnd(instances: Instances[]) {
+    // Function to find date range end, if any
+    function FindDateRangeEnd(instances: Instances[]) {
         var maxValue = Number.MIN_VALUE;
         if (instances) {
+            var minStartDate = FindDateRangeStart(instances);
             for (var i = 0; i < instances.length; i++) {
+                let date_range_start = instances[i].manuscript_date_range_start;
                 let date_range_end = instances[i].manuscript_date_range_end;
-                if (date_range_end) {
-                    if (date_range_end > maxValue) {
-                        maxValue = date_range_end;
+                if (date_range_start && date_range_start === minStartDate) {
+                    if (date_range_end) {
+                        if (date_range_end > maxValue) {
+                            maxValue = date_range_end;
+                        }
                     }
                 }
             }
@@ -61,8 +65,8 @@ export const StoryInformationWidget = (props: any) => {
         return maxValue;
     }
 
-    // Function to find minimum date range start, if any
-    function FindMinimumDateRangeStart(instances: Instances[]) {
+    // Function to find date range start, if any
+    function FindDateRangeStart(instances: Instances[]) {
         var minValue = Number.MAX_VALUE;
         if (instances) {
             for (var i = 0; i < instances.length; i++) {
@@ -78,20 +82,20 @@ export const StoryInformationWidget = (props: any) => {
     }
 
     // Function to write the minimum (earliest year) manuscript date range start
-    const MinDateRangeStart = (instances: Instances[]) => {
-        var minValue = FindMinimumDateRangeStart(instances);
+    const ConstructDateRangeStart = (instances: Instances[]) => {
+        var minValue = FindDateRangeStart(instances);
         return <> {minValue} </>;
     }
 
     // Function to write the maximum (latest year) manuscript date range end
-    const MaxDateRangeEnd = (instances: Instances[]) => {
-        var maxValue = FindMaximumDateRangeEnd(instances);
+    const ConstructDateRangeEnd = (instances: Instances[]) => {
+        var maxValue = FindDateRangeEnd(instances);
         return <> {maxValue} </>;
     }
 
     // Function to write the earliest attested instance of the story with the manuscript date range start and end
     const ConstructEarliestAttestedInstanceOfTheStory = (instances: Instances[]) => {
-        return <> <Typography variant="body2"> <b>Earliest Attested Instance of the Story:</b> {MinDateRangeStart(instances)}-{MaxDateRangeEnd(instances)} </Typography> </>
+        return <> <Typography variant="body2"> <b>Earliest Attested Instance of the Story:</b> {ConstructDateRangeStart(instances)}-{ConstructDateRangeEnd(instances)} </Typography> </>
     }
 
     // Function to write earliest manuscripts in which story appears, if any

--- a/src/components/elements/storyInformationWidget.tsx
+++ b/src/components/elements/storyInformationWidget.tsx
@@ -45,24 +45,20 @@ export const StoryInformationWidget = (props: any) => {
         return;
     }
 
-    // Function to find date range end, if any
+    // // Function to find date range end, if any
     function FindDateRangeEnd(instances: Instances[]) {
-        var maxValue = Number.MIN_VALUE;
+        var minValue = Number.MAX_VALUE;
         if (instances) {
-            var minStartDate = FindDateRangeStart(instances);
             for (var i = 0; i < instances.length; i++) {
-                let date_range_start = instances[i].manuscript_date_range_start;
                 let date_range_end = instances[i].manuscript_date_range_end;
-                if (date_range_start && date_range_start === minStartDate) {
-                    if (date_range_end) {
-                        if (date_range_end > maxValue) {
-                            maxValue = date_range_end;
-                        }
+                if (date_range_end) {
+                    if (date_range_end < minValue) {
+                        minValue = date_range_end;
                     }
                 }
             }
         }
-        return maxValue;
+        return minValue;
     }
 
     // Function to find date range start, if any
@@ -81,16 +77,16 @@ export const StoryInformationWidget = (props: any) => {
         return minValue;
     }
 
-    // Function to write the minimum (earliest year) manuscript date range start
+    // Function to write the minimum manuscript date range start
     const ConstructDateRangeStart = (instances: Instances[]) => {
         var minValue = FindDateRangeStart(instances);
         return <> {minValue} </>;
     }
 
-    // Function to write the maximum (latest year) manuscript date range end
+    // Function to write the minimum manuscript date range end
     const ConstructDateRangeEnd = (instances: Instances[]) => {
-        var maxValue = FindDateRangeEnd(instances);
-        return <> {maxValue} </>;
+        var minValue = FindDateRangeEnd(instances);
+        return <> {minValue} </>;
     }
 
     // Function to write the earliest attested instance of the story with the manuscript date range start and end

--- a/src/components/elements/storyTranslationAndCitation.tsx
+++ b/src/components/elements/storyTranslationAndCitation.tsx
@@ -4,9 +4,9 @@ export const StoryTranslationAndCitation = (props: any) => {
     const story = props.story;
 
     // Function to write english translation author, if any
-    const ConstructEnglishTranslationAuthor = (english_translation_author: string, english_translation_manuscript_name: string, english_translation_manuscript_folio: string) => {
-        if (english_translation_author != null) {
-            return <> <Typography variant="body2"> Translated by {english_translation_author} from {english_translation_manuscript_name}, f. {english_translation_manuscript_folio}.</Typography> </>
+    const ConstructEnglishTranslationAuthor = (translation_author: string, translation_source_manuscript_name: string, translation_source_manuscript_folio: string) => {
+        if (translation_author != null) {
+            return <> <Typography variant="body2"> Translated by {translation_author} from {translation_source_manuscript_name}, {translation_source_manuscript_folio}.</Typography> </>
         }
         return;
     }
@@ -20,10 +20,10 @@ export const StoryTranslationAndCitation = (props: any) => {
     }
 
     // Function to write translation citation, if any
-    const ConstructTranslationCitation = (english_translation_author: string, macomber_id: string, macomber_title: string) => {
+    const ConstructTranslationCitation = (translation_author: string, macomber_id: string, macomber_title: string) => {
         const last_modified_date = new Date();
-        if (english_translation_author != null && macomber_id != null && macomber_title != null) {
-            return <> <Typography variant="subtitle1" fontWeight="bold"> TO CITE THIS TRANSLATION </Typography> <Typography variant="body2"> {english_translation_author}. &quot;ID {macomber_id}: {macomber_title}.&quot; In <i>Täˀammərä Maryam (Miracle of Mary) Stories</i>, edited by Wendy Laura Belcher, Jeremy Brown, Mehari Worku, and Dawit Muluneh. Princeton: Princeton Ethiopian, Eritrean, and Egyptian Miracles of Mary project. http://pemm.princeton.edu/story-detail/{macomber_id}. Last modified: {last_modified_date.toLocaleDateString().replace(/\//ig, '.')}.</Typography> </>
+        if (translation_author != null && macomber_id != null && macomber_title != null) {
+            return <> <Typography variant="subtitle1" fontWeight="bold"> TO CITE THIS TRANSLATION </Typography> <Typography variant="body2"> {translation_author}. &quot;ID {macomber_id}: {macomber_title}.&quot; In <i>Täˀammərä Maryam (Miracle of Mary) Stories</i>, edited by Wendy Laura Belcher, Jeremy Brown, Mehari Worku, and Dawit Muluneh. Princeton: Princeton Ethiopian, Eritrean, and Egyptian Miracles of Mary project. http://pemm.princeton.edu/story-detail/{macomber_id}. Last modified: {last_modified_date.toLocaleDateString().replace(/\//ig, '.')}.</Typography> </>
         }
         return;
     }
@@ -88,10 +88,10 @@ export const StoryTranslationAndCitation = (props: any) => {
     return (
         <>
             <Typography variant="subtitle1" fontWeight="bold"> TRANSLATION </Typography>
-            {ConstructEnglishTranslationAuthor(story.english_translation_author, story.english_translation_manuscript_name, story.english_translation_manuscript_folio)}
+            {ConstructEnglishTranslationAuthor(story.translation_author, story.translation_source_manuscript_name, story.translation_source_manuscript_folio)}
             {ConstructEnglishTranslation(story.english_translation)}
             <div className='mt-5'>
-                {ConstructTranslationCitation(story.english_translation_author, story.macomber_id, story.macomber_title)}
+                {ConstructTranslationCitation(story.translation_author, story.macomber_id, story.macomber_title)}
             </div>
             <div className='mt-5'>
                 {ConstructOtherTranslations(story.appears_in_arabic, story.appears_in_french, story.appears_in_amharic, story.appears_in_latin, story.appears_in_italian, story.print_version)}


### PR DESCRIPTION
### 1. Home Page
- Implemented the responsive mobile-view navigation bar
### 2. Story Detail Page
- Edited the `FindDateRangeEnd` function in the `storyInformationWidget` component to get the date range end for the earliest attested instance of the story
- Updated `Earliest Attested Instance of the Story`: first and last date of the earliest manuscript to the latest manuscript (example: 1400 - 1499)
- Updated `translation author` and `translation citation` (including date) under the `TRANSLATION` and `TO CITE THIS TRANSLATION` sections, respectively
- Used the `Math.floor` static method in `manuscriptInformationBox` to fix the century number categorisation.

### 3. Sprint Summary
- All sprint tasks were completed within the schedule

### 4. Testing Screenshots
Implemented the responsive mobile-view navigation bar on the home page
<img width="369" alt="Screenshot 2023-03-20 at 11 34 54 AM" src="https://user-images.githubusercontent.com/67703799/226396425-6cc93b14-2f27-472c-be46-a1d580958cb1.png">

Updated the `translation citation` and included the last modified date - `TO CITE THIS TRANSLATION` section on the Story Detail Page
<img width="896" alt="Screenshot 2023-03-20 at 12 19 54 PM" src="https://user-images.githubusercontent.com/67703799/226396503-a30d5faf-1443-4193-a873-fa38772fe9e9.png">

`Earliest Attested Instance of the Story` updated to be the minimum `date range start` and `date range end` on the same row
<img width="429" alt="Screenshot 2023-03-20 at 2 06 48 PM" src="https://user-images.githubusercontent.com/67703799/226396792-1c792fda-d2e3-4263-b797-194b80c0cf61.png">

The translation author is displayed - `TRANSLATION` section on the Story Detail Page (Story 13)
<img width="404" alt="Screenshot 2023-03-20 at 2 38 41 PM" src="https://user-images.githubusercontent.com/67703799/226396833-600dabae-7380-44f5-89f8-16887b6faacc.png">

Filtered 11 manuscripts from 1400 - 1499 for Story 13 
<img width="1680" alt="Screenshot 2023-03-20 at 3 07 08 PM" src="https://user-images.githubusercontent.com/67703799/226396960-d823f614-4fa6-46f2-b8dd-40fb2343b08f.png">

All 11 manuscripts from 1400 - 1499 are displayed for Story 13 - `MANUSCRIPT` section on the Story Detail Page
<img width="840" alt="Screenshot 2023-03-20 at 3 15 33 PM" src="https://user-images.githubusercontent.com/67703799/226397082-1a41254e-102e-4647-9057-eb3e0dea7156.png">