### PR TITLE
Ticket Bug Fixes

### DIFF
--- a/src/components/elements/manuscriptCatalogedMiracleRecords.tsx
+++ b/src/components/elements/manuscriptCatalogedMiracleRecords.tsx
@@ -25,12 +25,6 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
   // Check if incipit field is empty (null) for all stories in the manuscript
   const isIncipitEmpty = manuscript.story_instances.every((row: any) => !row.incipit);
 
-  // Check if total_tm_paintings field is 0 for the manuscript
-  const isPaintingsHidden = manuscript.total_tm_paintings === 0;
-
-  // Check if recension_id field is empty (null) for all stories in the manuscript
-  const isRecensionEmpty = manuscript.story_instances.every((row: any) => !row.recension_id);
-
   return (
     <>
       <TableContainer sx={{
@@ -63,17 +57,6 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                   Story Title
                 </Typography>
               </TableCell>
-              {/* <TableCell
-                colSpan={1}
-                align="left"
-                sx={{
-                  wordWrap: "break-word",
-                  whiteSpace: 'normal',
-                }}>
-                <Typography fontWeight={"bold"} variant="subtitle2" color={secondary}>
-                  ID Certainty
-                </Typography>
-              </TableCell> */}
               <TableCell
                 colSpan={1}
                 align="left"
@@ -96,30 +79,28 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                   Number in MS
                 </Typography>
               </TableCell>
-              {!isRecensionEmpty && (
-                <TableCell
-                  colSpan={1}
-                  align="left"
-                  sx={{
-                    wordWrap: "break-word",
-                    whiteSpace: 'normal',
-                  }}>
-                  <Typography fontWeight={"bold"} variant="subtitle2" color={secondary}>
-                    Story Recension by MS
-                  </Typography>
-                </TableCell>)}
-              {!isPaintingsHidden && (
-                <TableCell
-                  colSpan={1}
-                  align="left"
-                  sx={{
-                    wordWrap: "break-word",
-                    whiteSpace: 'normal',
-                  }}>
-                  <Typography fontWeight={"bold"} variant="subtitle2" color={secondary}>
-                    Paintings of Story in MS
-                  </Typography>
-                </TableCell>)}
+              <TableCell
+                colSpan={1}
+                align="left"
+                sx={{
+                  wordWrap: "break-word",
+                  whiteSpace: 'normal',
+                }}>
+                <Typography fontWeight={"bold"} variant="subtitle2" color={secondary}>
+                  Story Recension by MS
+                </Typography>
+              </TableCell>
+              <TableCell
+                colSpan={1}
+                align="left"
+                sx={{
+                  wordWrap: "break-word",
+                  whiteSpace: 'normal',
+                }}>
+                <Typography fontWeight={"bold"} variant="subtitle2" color={secondary}>
+                  Paintings of Story in MS
+                </Typography>
+              </TableCell>
               {!isIncipitEmpty && (
                 <TableCell
                   colSpan={1}
@@ -140,18 +121,7 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                   whiteSpace: 'normal',
                 }}>
                 <Typography fontWeight={"bold"} variant="subtitle2" color={secondary}>
-                  Stanzas
-                </Typography>
-              </TableCell>
-              <TableCell
-                colSpan={1}
-                align="left"
-                sx={{
-                  wordWrap: "break-word",
-                  whiteSpace: 'normal',
-                }}>
-                <Typography fontWeight={"bold"} variant="subtitle2" color={secondary}>
-                  Symbols
+                  Other Aspects
                 </Typography>
               </TableCell>
             </StyledTableRow>
@@ -182,14 +152,6 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                   align="left">
                   {row.macomber_title}
                 </TableCell>
-                {/* <TableCell
-                  sx={{
-                    wordWrap: "break-word",
-                    whiteSpace: 'normal',
-                  }}
-                  align="left">
-                  {row.confidence_score}
-                </TableCell> */}
                 <TableCell
                   sx={{
                     wordWrap: "break-word",
@@ -214,20 +176,20 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                   align="left">
                   {row.recension_id}
                 </TableCell>
-                {!isPaintingsHidden && (
-                  <TableCell
-                    sx={{
-                      wordWrap: "break-word",
-                      whiteSpace: 'normal',
-                    }}
-                    align="left">
-                    {row.no_of_paintings_per_story_instance}
-                  </TableCell>)}
+                <TableCell
+                  sx={{
+                    wordWrap: "break-word",
+                    whiteSpace: 'normal',
+                  }}
+                  align="left">
+                  {row.no_of_paintings_per_story_instance}
+                </TableCell>
                 {!isIncipitEmpty && (
                   <TableCell
                     sx={{
                       wordWrap: "break-word",
                       whiteSpace: 'normal',
+                      width: '600px', // Adjust the width of the incipit column
                     }}
                     align="left">
                     {row.incipit}
@@ -238,15 +200,7 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                     whiteSpace: 'normal',
                   }}
                   align="left">
-                  {row.stanza}
-                </TableCell>
-                <TableCell
-                  sx={{
-                    wordWrap: "break-word",
-                    whiteSpace: 'normal',
-                  }}
-                  align="left">
-                  {row.total_records === 1 ? "☆" : ""} {row.stanza === "Yes" ? "♫" : ""} {(row.confidence_score === "Low" || row.confidence_score === "Medium") ? "(−)" : ""}
+                  {row.total_records === 1 ? "☆" : ""} {row.stanza === "Yes" ? "♫" : ""} {(row.confidence_score === "Low" || row.confidence_score === "Medium") ? "(?)" : ""}
                 </TableCell>
               </TableRow>
             ))}

--- a/src/components/elements/manuscriptInformationBox.tsx
+++ b/src/components/elements/manuscriptInformationBox.tsx
@@ -1,7 +1,7 @@
 import Typography from '@mui/material/Typography';
 
 // List of all the centuries we currently have story instances in.
-const CENTURIES: [number, string][] = [[13, '1300s'], [14, '1400s'], [15, '1500s'], [16, '1600s'], [17, '1700s'], [18, '1800s'], [19, '1900s']];
+const CENTURIES: [number, string][] = [[13, '1300s'], [14, '1400s'], [15, '1500s'], [16, '1600s'], [17, '1700s'], [18, '1800s'], [19, '1900s'], [20, '2000s']];
 
 export const ManuscriptInformationBox = (props: any) => {
     const INSTANCES = props.instances;
@@ -43,7 +43,7 @@ export const ManuscriptInformationBox = (props: any) => {
     return (
         <>
             <Typography variant="subtitle1"> <b>MANUSCRIPTS</b> </Typography>
-            <Typography variant="body2"> GMP Manuscripts in which story appears (with page or folio start): </Typography>
+            <Typography variant="body2"> PEMM Manuscripts in which story appears (with page or folio start): </Typography>
             {CENTURIES.map(function (century, i) {
                 return (
                     <div className='block' key={i}>

--- a/src/components/types/stories.ts
+++ b/src/components/types/stories.ts
@@ -50,4 +50,7 @@ export type Stories = {
     folio_start?: string | null,
     folio_end?: string | null,
     translations?: Array<any> | null,
+    canonical_translation_recension?: boolean | null,
+    translation_status?: string | null,
+    translation_author?: string | null,
   }


### PR DESCRIPTION
### Ticket #104 - Manuscript Catalog Records Bugs
- https://github.com/PrincetonPEMM/pemm-issues/issues/104
- [x]  “Story Recension by MS” column is always present even if the values are NULL
- [x]  “Paintings of Story in MS” column is always present and displays all 0s
- [x]  Alignment of the columns (Manuscript 13 and others)
- [x]  “Stanza” column is not required
- [x]  Replaced the (-) sign with a (?) in “Other Aspects” column
- [x]  Replaced the table heading “Symbols” with “Other Aspects”
- [x] "Incipit" column has a wider cell width according to the ticket requirements

### Ticket #96 - Story Details Page Translations, Citations, Manuscripts
- https://github.com/PrincetonPEMM/pemm-issues/issues/96
- [x]  Included the 2000s for Manuscripts list on the Story Details Page

### Ticket #87 - Earliest Attested Instance of the Story
- https://github.com/PrincetonPEMM/pemm-issues/issues/87
- [x]  “Earliest Attested Instance of the Story” bug is fixed for the Story Details Page
- [x]  Edited the SQL query in the AWS Lambda function - `getStoryInstanceByManuscript`

<img width="1287" alt="Screenshot 2023-05-31 at 5 36 38 PM" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/ae246ef4-258f-448a-9388-8b38c91740fe">
Figure 1: SQL query in `getStoryInstanceByManuscript` is fixed for correct “Earliest Attested Instance of the Story”

<img width="1680" alt="Screenshot 2023-05-31 at 5 35 51 PM" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/bd4e7096-4d71-46d2-853f-221a469e1a54">
Figure 2: Example - Story ID 2 has a correct Earliest Attested Instance of the Story: 1517 - 1518

<img width="1295" alt="Screenshot 2023-05-31 at 6 03 43 PM" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/ae7120a3-e325-44e1-a8e7-ef16125548a3">
Figure 3: Included the 2000s for manuscripts list on the Story Details page

<img width="1272" alt="Screenshot 2023-05-31 at 6 08 57 PM" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/f06f13e0-e75d-433e-9a3e-779078b7f831">
Figure 4: Fixed bugs and updated manuscript catalogued records. Please see lab1 (https://lab1.dtma86dor8lfe.amplifyapp.com/manuscripts/13) for updated changes as mentioned.