### PR TITLE
Story Translation Citation Modified Date Fix

### DIFF
--- a/src/components/elements/storyTranslationAndCitation.tsx
+++ b/src/components/elements/storyTranslationAndCitation.tsx
@@ -7,10 +7,10 @@ export const StoryTranslationAndCitation = (props: any) => {
     const ConstructEnglishTranslationAuthor = (translation_author: string, translation_source_manuscript_name: string, translation_source_manuscript_folio: string, translations: any) => {
 
         let translation_date = null
-        if (translations != null){
-            for (let tran of translations){
+        if (translations != null) {
+            for (let tran of translations) {
                 if (!tran.language_translated_to) continue;
-                if (tran.language_translated_to.toLowerCase() == "english"){
+                if (tran.language_translated_to.toLowerCase() == "english") {
                     translation_date = <>, in {tran.translation_as_of_date}</>
                     break
                 }
@@ -32,11 +32,23 @@ export const StoryTranslationAndCitation = (props: any) => {
     }
 
     // Function to write translation citation, if any
-    const ConstructTranslationCitation = (translation_author: string, macomber_id: string, macomber_title: string) => {
-        const last_modified_date = new Date();
-        if (translation_author != null && macomber_id != null && macomber_title != null) {
-            return <> <Typography variant="subtitle1" fontWeight="bold"> TO CITE THIS TRANSLATION </Typography> 
-            <Typography variant="body2"> {translation_author}. &quot;ID {macomber_id}: {macomber_title}.&quot; In <i>Täˀammərä Maryam (Miracle of Mary) Stories</i>, edited by Wendy Laura Belcher, Jeremy Brown, Mehari Worku, and Dawit Muluneh. Princeton: Princeton Ethiopian, Eritrean, and Egyptian Miracles of Mary project. http://pemm.princeton.edu/story-detail/{macomber_id}. Last modified: {last_modified_date.toLocaleDateString().replace(/\//ig, '.')}.</Typography> </>
+    const ConstructTranslationCitation = (translation_author: string, macomber_id: string, macomber_title: string, translations: any) => {
+
+        // Get modified date, where the language translated to is English
+        let translation_date = null
+        if (translations != null) {
+            for (let tran of translations) {
+                if (!tran.language_translated_to) continue;
+                if (tran.language_translated_to.toLowerCase() == "english") {
+                    translation_date = <>{tran.translation_as_of_date}</>
+                    break
+                }
+            }
+        }
+
+        if (translation_author != null && macomber_id != null && macomber_title != null && translation_date != null) {
+            return <> <Typography variant="subtitle1" fontWeight="bold"> TO CITE THIS TRANSLATION </Typography>
+                <Typography variant="body2"> {translation_author}. &quot;ID {macomber_id}: {macomber_title}.&quot; <i>Täˀammərä Maryam (Miracle of Mary) Stories</i>, edited by Wendy Laura Belcher, Jeremy Brown, Mehari Worku, and Dawit Muluneh. Princeton: Princeton Ethiopian, Eritrean, and Egyptian Miracles of Mary project. http://pemm.princeton.edu/story-detail/{macomber_id}. Last modified: {translation_date}.</Typography> </>
         }
         return;
     }
@@ -46,32 +58,32 @@ export const StoryTranslationAndCitation = (props: any) => {
         let citations = []
         let translation_status_options: string[] = ["Published translation", "Complete Translation", "Complete Unpublished Translation"]
 
-        if (translations != null){
-            for(let tran of translations){
-                if (!tran.canonical_translation_recension){
-                    if (translation_status_options.includes(tran.translation_status)){
+        if (translations != null) {
+            for (let tran of translations) {
+                if (!tran.canonical_translation_recension) {
+                    if (translation_status_options.includes(tran.translation_status)) {
                         let p1 = <><b>{tran.language_translated_to}: </b></>
                         let p2 = <>{tran.translation_author}. {tran.translation_as_of_date}. {tran.published_translation_book_title}</>
-                        
+
                         let p3 = null
-                        if(tran.published_translation_book_page_span){
+                        if (tran.published_translation_book_page_span) {
                             p3 = <>, pages {tran.published_translation_book_page_span}. </>
                         }
-                        else if(tran.published_translation_book_item){
+                        else if (tran.published_translation_book_item) {
                             p3 = <>, item {tran.published_translation_book_item}. </>
                         }
-    
+
                         let p4 = null
-                        if (tran.translation_source_manuscript_name && tran.translation_source_manuscript_folio){
+                        if (tran.translation_source_manuscript_name && tran.translation_source_manuscript_folio) {
                             p4 = <>From {tran.translation_source_manuscript_name}, {tran.translation_source_manuscript_folio}</>
                         }
-        
+
                         citations.push(<h2>{p1}{p2}{p3}{p4}</h2>)
                     }
                 }
             }
         }
-       
+
         return citations
     }
 
@@ -138,11 +150,11 @@ export const StoryTranslationAndCitation = (props: any) => {
             {ConstructEnglishTranslationAuthor(story.translation_author, story.translation_source_manuscript_name, story.translation_source_manuscript_folio, story.translations)}
             {ConstructEnglishTranslation(story.english_translation)}
             <div className='mt-5'>
-                {ConstructTranslationCitation(story.translation_author, story.macomber_id, story.macomber_title)}
+                {ConstructTranslationCitation(story.translation_author, story.macomber_id, story.macomber_title, story.translations)}
             </div>
-            { <div className='mt-5'>
+            {<div className='mt-5'>
                 {ConstructOtherTranslations(story.appears_in_arabic, story.appears_in_french, story.appears_in_amharic, story.appears_in_latin, story.appears_in_italian, story.print_version)}
-            </div> }
+            </div>}
             {NewConstructTranslationCitations(story.translations)}
         </>
     );


### PR DESCRIPTION
- The English story translation citation uses the `translation_as_of_date`, where the `language_translated_to` is `English`.
- The bug previously used the current local date (i.e. MM.DD.YYYY), which is incorrect.
- Logic was implemented in the `ConstructTranslationCitation` function to get the modified date, where the language translated to is English
- Please see the following sample changes for Stories 10, 12, and 13.

Figure 1: The highlighted `translation_as_of_date`, where the `language_translated_to` is `English`
<img width="1680" alt="translation-as-of-date-highlight" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/280a0eff-c40a-4892-8403-0114c9e0e106">

Figure 2: The last modified date in Story 10's translation citation.
<img width="856" alt="story-10-citation-modified-date" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/99a3e0a7-175a-428e-9b04-a5dabff199f0">

Figure 3: The last modified date in Story 12's translation citation
<img width="859" alt="story-12-citation-modified-date" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/3833cb06-eb31-4e2f-bdd1-548fbceaa28a">

Figure 4: The last modified date in Story 13's translation citation.
<img width="856" alt="story-13-citation-modified-date" src="https://github.com/PrincetonPEMM/pemm-website/assets/67703799/1f96fb02-983b-41bf-bfbe-9402c670727f">