### PR TITLE
Story Title Column Width Fix

### DIFF
--- a/src/components/elements/manuscriptCatalogedMiracleRecords.tsx
+++ b/src/components/elements/manuscriptCatalogedMiracleRecords.tsx
@@ -148,6 +148,7 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                   sx={{
                     wordWrap: "break-word",
                     whiteSpace: 'normal',
+                    width: '550px', // Adjust the width of the story title column
                   }}
                   align="left">
                   {row.macomber_title}
@@ -189,7 +190,7 @@ const ManuscriptCatalogedMiracleRecords = (props: any) => {
                     sx={{
                       wordWrap: "break-word",
                       whiteSpace: 'normal',
-                      width: '600px', // Adjust the width of the incipit column
+                      width: '5500px', // Adjust the width of the incipit column
                     }}
                     align="left">
                     {row.incipit}


### PR DESCRIPTION
Fixed the width of the story title column and make it responsive on the interface.
![story-title-column-width-fix](https://github.com/PrincetonPEMM/pemm-website/assets/67703799/fd43f618-54cd-4fdb-8eae-d38b2535eaf9)
